### PR TITLE
Allow moving multiple tabs with tabs context menu

### DIFF
--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -55,9 +55,12 @@ function tabContextMenuAction(info, tab) {
 			await setStash(windowId, groupId, false, true);
 		}
 
-		await TABINTERFACE.setGroupId(tab.id, groupId);
+		let highlighted = await browser.tabs.query({highlighted: true, currentWindow: true});
+		highlighted.forEach(async (tab) => {
+			await TABINTERFACE.setGroupId(tab.id, groupId);
+		})
 
-		if (tab.active) {
+		if (tab.active || tab.highlighted) {
 			await TABINTERFACE.setActiveGroup(windowId, groupId);
 		}
 

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -146,6 +146,15 @@ async function initContextMenu() {
 
 	browser.menus.onShown.addListener(async function (info, tab) {
 		if (info.contexts.includes('tab')) {
+			let menuId = tabContextRoot.id;
+			let highlighted = await browser.tabs.query({highlighted: true, currentWindow: true});
+
+			if (tab.highlighted && highlighted.length > 1) {
+				browser.menus.update(menuId, { title: "Move tabs to group" });
+			} else {
+				browser.menus.update(menuId, { title: "Move tab to group" });
+			}
+
 			updateContextMenu(tab.windowId);
 			browser.menus.refresh();
 		}

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -55,10 +55,14 @@ function tabContextMenuAction(info, tab) {
 			await setStash(windowId, groupId, false, true);
 		}
 
-		let highlighted = await browser.tabs.query({highlighted: true, currentWindow: true});
-		highlighted.forEach(async (tab) => {
+		if (tab.highlighted) {
+			let highlighted = await browser.tabs.query({highlighted: true, currentWindow: true});
+			highlighted.forEach(async (tab) => {
+				await TABINTERFACE.setGroupId(tab.id, groupId);
+			})
+		} else {
 			await TABINTERFACE.setGroupId(tab.id, groupId);
-		})
+		}
 
 		if (tab.active || tab.highlighted) {
 			await TABINTERFACE.setActiveGroup(windowId, groupId);


### PR DESCRIPTION
Now that multiple tabs can be selected in Firefox tabs bar, it would be handy to be able to move multiple tabs using the tabs context menu.

To get the selected tabs, we should query the `highlighted` ones instead of just the `active` (the `active` is also `highlighted`):

```js
browser.tabs.query({highlighted: true, currentWindow: true})
```

So I tried to implement this, and it seems to be working.