### PR TITLE
Add a simple keyboard navigation to the popup

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -25,7 +25,8 @@ body
 	color: var(--active-color);
 }
 
-.group:hover
+.group:hover,
+.group:focus
 {
 	color: var(--hover-color);
 }
@@ -36,7 +37,8 @@ body
 	color: var(--text-medium);
 }
 
-#stash > .group:hover
+#stash > .group:hover,
+#stash > .group:focus
 {
 	color: var(--text-light);
 }


### PR DESCRIPTION
Add a simple way to navigate between groups in the popup with the keyboard using the HTML attribute `tabindex`. So, with the popup opened: 

- `tab` will move the focus to the next node on the list
- `shift+tab` will move the focus backwards on the list
- `enter` will activate the focused node or unstash it (if it is currently stashed)