### PR TITLE
Fix tab navigation order in the popup

### DIFF
--- a/src/js/groupInterface.js
+++ b/src/js/groupInterface.js
@@ -111,6 +111,10 @@ async function groupInterface(windowId) {
 		return array[index % array.length];
 	}
 
+	self.size = function () {
+		return Object.keys(groups).length;
+	}
+
 	self.forEach = async function (callback) {
 		let promises = [];
 		let n = array.length;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -125,7 +125,7 @@ async function makeGroupNodes() {
 
 		let node = new_element('div', {
 			class: 'group'
-			, tabindex: group.id + 1
+			, tabindex: group.index + 1
 		}, [text, unstash]);
 
 		unstash.addEventListener('click', async function (event) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -125,7 +125,6 @@ async function makeGroupNodes() {
 
 		let node = new_element('div', {
 			class: 'group'
-			, tabindex: group.index + 1
 		}, [text, unstash]);
 
 		unstash.addEventListener('click', async function (event) {
@@ -137,7 +136,7 @@ async function makeGroupNodes() {
 				if (group.stash) {
 					unstashNode(event);
 				} else {
-				selectNode(event);
+					selectNode(event);
 				}
 			}
 		});
@@ -165,6 +164,11 @@ async function updateGroupNodes() {
 
 	await GRPIFC.forEach(function (group) {
 		let node = nodes[group.id];
+		let tabindex = group.stash
+			? group.index + GRPIFC.size()
+			: group.index + 1
+
+		node.html.setAttribute('tabindex', tabindex)
 
 		if (node.stash) {
 			stashHolder.appendChild(node.html);
@@ -175,7 +179,6 @@ async function updateGroupNodes() {
 				numKeyTargets[i] = node.id;
 				node.text.innerHTML = `[${i}] ${node.name}`;
 			}
-
 
 			groupsHolder.appendChild(node.html);
 		}


### PR DESCRIPTION
In the previous PR I was using `group.id` to set the tabindex for each node when I should be using `group.index`.

As `group.id` corresponds to the order of creation of the group, that could led to an incorrect order of navigation when the user has reordered its groups. Instead, I should be using `group.index`, which reflects the current order of the groups.