### PR TITLE
Add Shortcut instructions with example syntax

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -17,6 +17,13 @@
 <section>
 	<h2>Shortcuts</h2>
 	<div id="shortcuts"></div>
+	<p>Use the <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands">Command API Syntax</a>. Examples:
+		<ul>
+			<li><code>F4</code></li>
+			<li><code>Ctrl+Shift+Y</code></li>
+			<li><code>Alt+F</code></li>
+		</ul>
+	</p>
 	<h3>Other shortcut options</h3>
 	<div><input id ="numKey" type ="checkbox"/><span>Use number keys as hotkeys when popup panel is displayed</span></div>
 </section>


### PR DESCRIPTION
As described in #5, I added instructions regarding the syntax to use for adding a shortcut, including a link to the Command API.

I don't know how to test firefox add-ons so please test this before merging.